### PR TITLE
Add ostree update scripts.

### DIFF
--- a/ostree/Docker/Dockerfile
+++ b/ostree/Docker/Dockerfile
@@ -1,3 +1,18 @@
+# Copyright (c) 2021, Pelion Limited and affiliates.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 FROM ubuntu:18.04
 
 RUN apt-get update && apt-get install locales \

--- a/ostree/Docker/Dockerfile
+++ b/ostree/Docker/Dockerfile
@@ -1,0 +1,33 @@
+FROM ubuntu:18.04
+
+RUN apt-get update && apt-get install locales \
+    && dpkg-reconfigure locales \
+    && locale-gen en_US.UTF-8 \
+    && update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+		python \
+		python3 \
+		python3-pip \
+		python3-pexpect \
+        python3-setuptools \
+		python-pip \
+		python-virtualenv
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        sudo \
+        coreutils \
+        gzip \
+        tar \
+        ostree
+
+ENV LANG en_US.UTF-8
+
+# Scripts used to build ostree static delta
+COPY ostree-delta.py ./
+COPY createOSTreeUpgrade.sh ./
+COPY Docker/entrypoint.sh /usr/local/bin/entrypoint.sh
+
+# Use the 'exec' form of ENTRYPOINT to ensure that docker run
+# invocation arguments are appended to the command line.
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/ostree/Docker/config-funcs.sh
+++ b/ostree/Docker/config-funcs.sh
@@ -1,8 +1,19 @@
 #!/bin/bash
 
-# Copyright (c) 2019, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2021, Pelion Limited and affiliates.
+# SPDX-License-Identifier: Apache-2.0
 #
-# SPDX-License-Identifier: BSD-3-Clause
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # BASH functions that can be "source"d into a script to provide simple
 # config functionality that supports command line options:

--- a/ostree/Docker/config-funcs.sh
+++ b/ostree/Docker/config-funcs.sh
@@ -1,0 +1,350 @@
+#!/bin/bash
+
+# Copyright (c) 2019, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# BASH functions that can be "source"d into a script to provide simple
+# config functionality that supports command line options:
+#   --save-config FILE      - save all the arguments into FILE and exit
+#   --load-config FILE      - load arguments from FILE and combine them
+#                             with the command line arguments
+#
+# Example usage to replace command line args ($@) with extra args from config:
+#   source config-funcs.sh
+#   config=()
+#   config_setup config "$@"
+#   eval set -- "${config[@]}"
+#
+# Notes:
+# * only supports options without values or options with a single value
+# * supports "--" option that splits primary and secondary arguments
+# * SC2178: Arrays passed around by reference confuses shellcheck
+#           https://github.com/koalaman/shellcheck/issues/1225
+# * SC2034: Arrays passed around by reference confuses shellcheck
+#           https://github.com/koalaman/shellcheck/issues/1543
+
+
+# Read arguments and values from a file
+# Split them into primary and secondary based on "--" in the file
+# Return bash arrays for the arguments and values to preserve spaces in values
+# Params: NAME ARRAY_REF ARRAY_REF
+_config_read_args()
+{
+  # Config filename and path
+  local config="$1"
+  # Array variable reference to put the arguments into
+  local -n config_primary=$2
+  local -n config_secondary=$3
+  local stage=1
+  if [ -r "$config" ]; then
+    while read -r line; do
+      if [[ "$line" =~ ^--\ *$ ]]; then
+        # Switch to secondary stage on "--"
+        stage=2
+        continue  # Skip the "--"
+      fi
+      local val
+      pat="^-[-a-z]+="
+      if [[ "$line" =~ $pat ]]; then
+        # Catch --option=value and don't split it
+        val="$line"
+      else
+        # Split the arguments and values for the array
+        val=${line#-* } # Remove the argument part
+      fi
+      if [ "$val" == "$line" ]; then
+        # No value, only an option (or option=value)
+        if [ $stage -eq 1 ]; then
+          config_primary+=("$line")
+        else
+          config_secondary+=("$line")
+        fi
+      else
+        local opt=${line% $val}
+        if [ $stage -eq 1 ]; then
+          config_primary+=("$opt" "$val")
+        else
+          config_secondary+=("$opt" "$val")
+        fi
+      fi
+    done < "$config"
+  fi
+}
+
+# Write arguments and values to a config file
+# Outputs the arguments as argument and value on the same line
+# NOTE: "--END--" must be last entry in list to end processing/output of the list
+# Params: NAME ARGS_LIST... --END--
+_config_write_args()
+{
+  # Config filename and path
+  local config="$1"
+  shift
+  if [ ! -e "$config" ] || [[ -w "$config" && -f "$config" ]]; then
+    # Create empty file
+    rm -f "$config"
+    touch "$config"
+    local lastarg=""
+    # Go through the other arguments (and values) saving them to a file
+    # "--END--" is assumed to be the last arg in the list (which is not output)
+    #  this forces the loop to output the "lastarg" before exiting
+    while [ $# -gt 0 ]; do
+      local arg="$1"
+      shift
+      if [ -z "$arg" ]; then
+        # Ignore empty arguments
+        continue
+      fi
+      if [[ "$arg" =~ ^- ]]; then
+        # An argument, output any previous argument on its own
+        if [ -n "$lastarg" ]; then
+          echo "$lastarg" >> "$config"
+        fi
+        lastarg=$arg
+      else
+        # A value - group arguments and values together
+        if [ -n "$lastarg" ]; then
+          echo "$lastarg $arg" >> "$config"
+        else
+          echo "$arg" >> "$config"
+        fi
+        lastarg=""
+      fi
+      if [ "$arg" == "--END--" ]; then
+        break
+      fi
+    done
+  fi
+}
+
+# Given a config, this will try and read args from that file
+# The arguments are split by "--" returned in bash arrays in the given refs
+# Params: NAME ARRAY_REF ARRAY_REF
+_config_read()
+{
+  local config="$1"
+  # shellcheck disable=SC2178
+  local -n config_primary=$2
+  # shellcheck disable=SC2178
+  local -n config_secondary=$3
+
+  if [ -r "${config}" ]; then
+    _config_read_args "${config}" "${!config_primary}" "${!config_secondary}"
+    if [ ${#config_primary[@]} -gt 0 ] || [ ${#config_secondary[@]} -gt 0 ]; then
+      echo "Read configuration from ${config}"
+    fi
+  else
+    echo "ERROR: Unreadable configuration file ${config}"
+    return 1
+  fi
+}
+
+# Write out the arguments to the given file
+# Params: NAME ARGS_LIST...
+_config_write()
+{
+  local config_file="$1"
+  shift
+  if [ -d "$(dirname "$config_file")" ]; then
+    if [ ! -e "$config_file" ] || [[ -w "$config_file" && -f "$config_file" ]]; then
+      echo "Saving configuration to $config_file"
+      _config_write_args "$config_file" "$@" "--END--"
+    else
+      echo "ERROR: Cannot write $config_file as invalid file"
+    fi
+  else
+    echo "ERROR: Cannot write $config_file as directory is invalid"
+    return 1
+  fi
+}
+
+# Read through the arguments for the given config option (without --) so we can
+# remove the option and return the option value - filename
+# Needs a reference to store the filename and the updated args list, and then
+# the full list of args to parse
+# option
+# NOTE: "--END--" must be last entry in list to end processing/output of the list
+# Params: NAME NAME_REF ARRAY_REF ARGS_LIST... --END--
+_config_get_filename()
+{
+  # We need to read the option to get the filename
+  local optname=$1
+  local -n ret_filename=$2
+  local -n ret_args=$3
+  shift 3
+  ret_args=()
+
+  # Go through each option/value looking for the option we want, and remove it
+  local lastarg=""
+  local optreturn=""
+  while [ $# -gt 0 ]; do
+    local arg="$1"
+    shift
+    if [ -z "$arg" ]; then
+      # Ignore empty arguments
+      continue
+    fi
+    local optcheck
+    if [[ "$arg" =~ ^- ]]; then
+      # An argument, check if the lastarg is the option we want
+      # (it will be in the form --option=value)
+      if [ -n "$lastarg" ]; then
+        set +e
+        optcheck=$(getopt -q -o+ -l "$optname:" -- "$lastarg")
+        set -e
+        # getopt returns " --" if its not the option we want
+        if [ "$optcheck" == " --" ]; then
+          ret_args+=("$lastarg")
+        else
+          # Save the output from getopt for later
+          optreturn="$optcheck"
+        fi
+      fi
+      # Save the argument to look at later with a possibly value
+      lastarg=$arg
+    else
+      # A value - check using the last argument and this value for the option
+      # (form of --option value)
+      set +e
+      optcheck=$(getopt -q -o+ -l "$optname:" -- "$lastarg" "$arg")
+      set -e
+      # getopt returns " -- '$arg'" if its not found as it removes unknown opts
+      if [[ "$optcheck" =~ ^\ --\  ]]; then
+          if [ -n "$lastarg" ]; then
+            ret_args+=("$lastarg")
+          fi
+          ret_args+=("$arg")
+      else
+        # Save the output from getopt for later
+        optreturn="$optcheck"
+      fi
+      lastarg=""
+    fi
+    if [ "$arg" == "--END--" ]; then
+      break
+    fi
+  done
+  ret_filename=""
+  if [ -n "$optreturn" ]; then
+    # Extract the file from the last found "--option 'FILE' --"
+    ret_filename=${optreturn##*$optname \'}
+    ret_filename=${ret_filename%%\' --*}
+  fi
+}
+
+# Combine the command line (cl) arguments with the config arguments, such that:
+# [primary config] [cl args (before --)] -- [secondary args] [cl args (after --)]
+# Params: ARRAY_REF ARRAY_REF ARRAY_REF ARGS_LIST...
+_config_combine_args()
+{
+  # shellcheck disable=SC2178
+  local -n ret_args=$1
+  # shellcheck disable=SC2178
+  local -n config_primary=$2
+  # shellcheck disable=SC2178
+  local -n config_secondary=$3
+  shift 3
+  ret_args=()
+
+  # Put the primary config args first
+  local arg
+  set +u # Ignore if the config_primary array is empty
+  for arg in "${config_primary[@]}"; do
+    ret_args+=("$arg")
+  done
+  set -u
+  # Next add all the command line arguments upto "--"
+  while [ $# -gt 0 ]; do
+    arg="$1"
+    shift
+    if [[ "$arg" =~ ^--\ *$ ]]; then
+      # Found "--" exit the loop without recording it as we may get arguments
+      # that don't contain "--"
+      break
+    fi
+    ret_args+=("$arg")
+  done
+  # Add the delimiter between args (in case it wasn't in the command line)
+  ret_args+=("--")
+  # Now add the secondary config args
+  set +u # Ignore if the config_secondary array is empty
+  for arg in "${config_secondary[@]}"; do
+    ret_args+=("$arg")
+  done
+  set -u
+  # Lastly add any remaining args
+  while [ $# -gt 0 ]; do
+    ret_args+=("$1")
+    shift
+  done
+}
+
+# Single quote all arguments
+# Needed for the eval operation (eval set -- "${config[@]}") that will be
+# perfomed on the config after we return
+# Params: ARRAY_REF ARGS_LIST...
+_config_add_quotes()
+{
+  # shellcheck disable=SC2178
+  local -n ret_args=$1
+  shift 1
+  ret_args=()
+
+  while [ $# -gt 0 ]; do
+    if [ "$1" != "--" ]; then
+      ret_args+=("'$1'")
+    else
+      ret_args+=("$1")
+    fi
+    shift
+  done
+}
+
+# Single config read/write function
+# First parameter is used on read and is an array populated with the combined
+# command line and config arguments
+# Rest of parameters are the command line args passed via "$@"
+# On write, command line args are written to file and then exit
+# Params: ARRAY_REF ARGS_LIST...
+config_setup()
+{
+  local -n config_args=$1
+  shift
+
+  # Avoid circular references by unique naming of arrays
+  local __args=()
+  # shellcheck disable=SC2034
+  local __config_primary=()
+  # shellcheck disable=SC2034
+  local __config_secondary=()
+
+  local config_load=""
+  _config_get_filename "load-config" config_load __args "$@" "--END--"
+  local config_save=""
+  set +u  # __args could be empty, so allow unbound vars
+  _config_get_filename "save-config" config_save __args "${__args[@]}" "--END--"
+  set -u
+
+  if [ -n "$config_load" ] || [ -n "$config_save" ]; then
+    if [ "$config_save" == "$config_load" ]; then
+      echo "ERROR: Unsupported loading and saving to same config file - $config_save"
+      exit 2
+    fi
+  fi
+
+  # Support loading from one config and saving to another
+  if [ -n "$config_load" ]; then
+    _config_read "$config_load" __config_primary __config_secondary
+  fi
+  set +u  # __args could be empty, so allow unbound vars
+  _config_combine_args "${!config_args}" __config_primary __config_secondary "${__args[@]}"
+  set -u
+  if [ -n "$config_save" ]; then
+    set +u  # __args could be empty, so allow unbound vars
+    _config_write "$config_save" "${config_args[@]}"
+    set -u
+    exit 0
+  fi
+  _config_add_quotes "${!config_args}" "${config_args[@]}"
+}

--- a/ostree/Docker/entrypoint.sh
+++ b/ostree/Docker/entrypoint.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+# Copyright (c) 2019, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+set -u
+
+## UID/GID Management
+
+# We need to manage uid/gid inside a container because the workspace
+# VOLUME and the ssh agent authentication socket are shared between
+# inside and outside.  We explicit capture the users uid and gid at
+# 'docker run' and arrange for an entrypoint to create the necessary
+# user on the fly.
+
+# We need a username, but it doesn't matter what the name is, we only
+# care that uid/gid are anchored correctly.
+
+username="user"
+
+# These environment variables are typically set by
+# docker run -e LOCAL_UID=$(id -u) -e LOCAL_GID=$(id -g)
+
+LOCAL_UID=${LOCAL_UID:-9001}
+LOCAL_GID=${LOCAL_GID:-9001}
+
+printf "entrypoint: starting with UID=%d GID=%d\n" "$LOCAL_UID" "$LOCAL_GID"
+
+if groupadd -g "$LOCAL_GID" "$username"; then
+   _=
+else
+  # We are about to test the exit code of groupadd, hence there can
+  # be no statements inserted here before the if.
+
+  # An exit code 4 indicates gid already exists, this is ok, we ignore
+  # it, any other fail is a fail!
+  if [ $? -ne 4 ]; then
+    exit $?
+  fi
+fi
+
+if useradd --shell /bin/bash -u "$LOCAL_UID" -g "$LOCAL_GID" -G sudo -c "" -m "$username"; then
+  _=
+else
+  # We are about to test the exit code of useradd, hence there can
+  # be no statements inserted here before the if.
+
+  # An exit code 4 indicates uid already exists, this is ok, we ignore
+  # it, any other fail is a fail!
+  if [ $? -ne 4 ]; then
+    exit $?
+  fi
+fi
+
+export HOME=/home/"$username"
+
+sed -i 's/%sudo  ALL=(ALL:ALL) ALL/%sudo ALL=(ALL:ALL) NOPASSWD:ALL/' /etc/sudoers
+
+sudo -E -u "$username" "$@"

--- a/ostree/Docker/entrypoint.sh
+++ b/ostree/Docker/entrypoint.sh
@@ -1,8 +1,19 @@
 #!/bin/bash
 
-# Copyright (c) 2019, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2021, Pelion Limited and affiliates.
+# SPDX-License-Identifier: Apache-2.0
 #
-# SPDX-License-Identifier: BSD-3-Clause
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 set -u
 

--- a/ostree/README.md
+++ b/ostree/README.md
@@ -1,0 +1,53 @@
+# OSTree-update-scripts
+Build scripts and tools for the OSTree firmware images.  
+To create the images, ostree must either be installed on the system, or within a Docker container. 
+There are two ways of creating an update image:   
+   - between two wic images.
+   - between ostree repositories.   
+   
+These artifacts are produced during the yocto build.
+   
+Scripts are provided for both of these, and instructions for running directly or with Docker. The Docker method has been tested running on an Ubuntu 16.04 machine only.
+
+# Creating an upgrade tarball between wic images
+
+The createOSTreeUpdate.sh script can be used to create a field upgrade tarball.
+
+```
+> ./createOSTreeUpdate <old-wic> <new-wic> [upgrade-tag]
+```
+
+Notes:
+  1. The output is a gzipped tarball. 
+  1. old-wic and new-wic are the *.wic images produced by yocto build
+  1. output is < upgrade-tag ->data.tar.gz
+  1. createOSTreeUpdate mounts the partitions from the wic files on loopback devices. 2 free loopback devices are required.
+
+# Creating an upgrade tarball between ostree repos
+
+The ostree-delta.py script can be used to create a field upgrade tarball.
+
+```
+> ./ostree-delta.py <--repo repo> <--output output-dir> [--update_repo repo] [--to_sha sha] [--from_sha sha] [--commit message] [--generate_bin]
+```
+
+If using the Docker container use:
+
+```
+> ./ostree-delta-docker.sh <--repo=repo> <--output=output-dir> [--update_repo repo] -- [--to_sha sha] [--from_sha sha]  [--commit message] [--generate_bin]
+```
+
+   Where:
+
+   - `<--repo>` base repo folder for upgrade.
+   - `<--output>` output folder for upgrade artifacts.
+   - `[--update_repo]` optional repo used if two seperated build trees are to be used.
+   - `[--to_sha]` optional text string specifying the base sha for the upgrade.
+   - `[--from_sha]` optional text string specifying the base sha for the upgrade.
+   - `[--commit]` optional text string used when merging to seperate repos. Only applicable if ```--update_repo``` is specified.
+   - `[--generate_bin]` optional flag to force the data.tar.gz output to be renamed data.bin.
+
+Notes:
+  1. The output is a gzipped tarball. 
+  1. output is named data.tar-gz. If the `--generate_bin` option is provided then the output is renamed to data.bin 
+

--- a/ostree/README.md
+++ b/ostree/README.md
@@ -1,12 +1,12 @@
 # OSTree-update-scripts
-Build scripts and tools for the OSTree firmware images.  
-To create the images, ostree must either be installed on the system, or within a Docker container. 
-There are two ways of creating an update image:   
+Build scripts and tools for the OSTree firmware images.
+To create the images, ostree must either be installed on the system, or within a Docker container.
+There are two ways of creating an update image:
    - between two wic images.
-   - between ostree repositories.   
-   
-These artifacts are produced during the yocto build.
-   
+   - between OSTree repositories.
+
+These artifacts are produced during the Yocto build.
+
 Scripts are provided for both of these, and instructions for running directly or with Docker. The Docker method has been tested running on an Ubuntu 16.04 machine only.
 
 # Creating an upgrade tarball between wic images
@@ -18,12 +18,12 @@ The createOSTreeUpdate.sh script can be used to create a field upgrade tarball.
 ```
 
 Notes:
-  1. The output is a gzipped tarball. 
-  1. old-wic and new-wic are the *.wic images produced by yocto build
+  1. The output is a gzipped tarball.
+  1. old-wic and new-wic are the *.wic images produced by Yocto build
   1. output is < upgrade-tag ->data.tar.gz
   1. createOSTreeUpdate mounts the partitions from the wic files on loopback devices. 2 free loopback devices are required.
 
-# Creating an upgrade tarball between ostree repos
+# Creating an upgrade tarball between OSTree repositories
 
 The ostree-delta.py script can be used to create a field upgrade tarball.
 
@@ -44,10 +44,10 @@ If using the Docker container use:
    - `[--update_repo]` optional repo used if two seperated build trees are to be used.
    - `[--to_sha]` optional text string specifying the base sha for the upgrade.
    - `[--from_sha]` optional text string specifying the base sha for the upgrade.
-   - `[--commit]` optional text string used when merging to seperate repos. Only applicable if ```--update_repo``` is specified.
+   - `[--commit]` optional text string used when merging to seperate repositories. Only applicable if ```--update_repo``` is specified.
    - `[--generate_bin]` optional flag to force the data.tar.gz output to be renamed data.bin.
 
 Notes:
-  1. The output is a gzipped tarball. 
-  1. output is named data.tar-gz. If the `--generate_bin` option is provided then the output is renamed to data.bin 
+  1. The output is a gzipped tarball.
+  1. output is named data.tar-gz. If the `--generate_bin` option is provided then the output is renamed to data.bin
 

--- a/ostree/createOSTreeUpgrade.sh
+++ b/ostree/createOSTreeUpgrade.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (c) 2020, Arm Limited and affiliates.
+# Copyright (c) 2021, Pelion Limited and affiliates.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/ostree/createOSTreeUpgrade.sh
+++ b/ostree/createOSTreeUpgrade.sh
@@ -1,0 +1,214 @@
+#!/bin/bash
+
+# Copyright (c) 2020, Arm Limited and affiliates.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# TODO: add settings section to group all the hardcoded paths and values
+
+# Output a message if verbose mode is on
+blab() {
+    [ "$VERBOSE" = 1 ] && echo "$@"
+}
+
+# Verify that given binaries are available
+# Params: list of binaries, separated by space
+# Returns the number of missing binaries (0=success)
+require_binaries() {
+    local retval=0
+    for b in "$@"; do
+        type "$b" >/dev/null 2>&1 || {
+            echo >&2 "Please make sure binary $b is installed and available in the path."
+	    let retval++
+        }
+    done
+    return $retval
+}
+
+# Mount a partition inside a .wic file (or any image file flashable with dd)
+# Params:
+#    1 - .wic file name (with path if needed)
+#    2 - partition number [1-based] (leave blank to list partitions)
+#    3 - mount point (full path to where the partition will be mounted; will be created if it doesn't exist)
+#    4 - [optional] partition type (auto detected if not specified)
+# To unmount: sudo umount /path/to/mount/point
+mount_wic_partition() {
+    local wic_file="$1"
+    local partition_number="$2"
+    local mount_point="$3"
+    local partition_type="$4"
+    local partition_info start_sector=0 sector_count=0
+
+    [ -z "${wic_file}" ] && {
+        echo >&2 "Usage: mount_wic_partition <wic_file> [<partition_number> <mount_point> [partition_type]]"
+        return 2
+    }
+
+    [ -f "${wic_file}" ] || {
+        echo >&2 "Can't access image file ${wic_file}"
+        return 1
+    }
+
+    [ -z "${partition_number}" ] && {
+        fdisk -lu "${wic_file}"
+        return 0
+    }
+
+    [ -z "${mount_point}" ] && {
+        echo >&2 "You must specify a mount point"
+        return 3
+    }
+
+    partition_info=$(sfdisk -d "${wic_file}" | grep ': start=' | grep "${partition_number} : start" | head -1)
+    [ -z "${partition_info}" ] && {
+        echo >&2 "Partition ${partition_number} not found"
+        return 4
+    }
+
+    start_sector=$(echo "${partition_info}" | cut -d , -f 1 | cut -d = -f 2)
+    sector_count=$(echo "${partition_info}" | cut -d , -f 2 | cut -d = -f 2)
+    [ -z "${partition_type}" ] && {
+        partition_type=$(echo "${partition_info}" | cut -d , -f 3 | cut -d = -f 2)
+        case "$partition_type" in
+            c) partition_type=vfat;;
+            83) partition_type=ext4;;
+            *) echo "Unsupported partition type: ${partition_type}"
+               echo "${partition_info}"
+               return 5
+        esac
+    }
+
+    mkdir -p "${mount_point}"
+    blab Mounting wic partition "$partition_number" of "$wic_file" to "$mount_point"
+    sudo mount -o loop,rw,offset=$((512*${start_sector})),sizelimit=$((512*${sector_count})) -t ${partition_type} "${wic_file}" "${mount_point}"
+}
+
+# Convenience/symmetry function
+# Params:
+#    1 - mount point (or /dev name)
+umount_wic_partition() {
+    blab Umounting "$1"
+    sudo umount "$1"
+}
+
+# Generate diff and create tarball (and its md5) between one partition of two given images
+# Params:
+#    1 - old image file name
+#    2 - new image file name
+#    3 - partition number
+#    4 - [optional] temporary directory for packing/unpacking files [default: TMPDIR, fallback current directory]
+# Assumptions: workdir/pack exists and is used for the output tarball+md5
+ostree_diff_partition() {
+    local wic_old="$1"
+    local wic_new="$2"
+    local partition="$3"
+    local workdir="${4:-${TMPDIR:-$(pwd)}}"
+
+    blab "===> Diffing partition $partition"
+
+    mount_wic_partition "$wic_old" "$partition" "$workdir/old" || return 1
+    mount_wic_partition "$wic_new" "$partition" "$workdir/new" || {
+        umount_wic_partition "$workdir/old"
+        return 2
+    }
+
+    blab Running OSTree difftool
+    sudo ./ostree-delta.py --repo "$workdir/old/ostree/repo" --output $workdir/delta --update_repo "$workdir/new/ostree/repo"
+
+    umount_wic_partition "$workdir/old"
+    umount_wic_partition "$workdir/new"
+
+    rm -rf "$workdir/old" "$workdir/new" "$workdir/diff"
+}
+
+# Setup temporary working space
+#
+setupTemp() {
+    # TODO: make TMPDIR a parameter, not a global variable
+    TMPDIR=$(mktemp -d)
+    blab "===> Setting up workdir in $TMPDIR"
+}
+
+# Unmount partitions and remove temp files
+# Params:
+#    1 - [optional] temporary directory for packing/unpacking files [default: TMPDIR; for safety reasons, there is no fallback]
+cleanup() {
+    local workdir="${1:-${TMPDIR}}"
+    blab "===> Cleaning up $workdir"
+    # TODO: to avoid clobbering existing files if workdir was not a fresh directory: instead of rm -rf workdir, remove only pack/ and field/, then use rmdir
+    [ -n "$workdir" ] && rm -rf "$workdir"
+}
+
+# Main function
+# Takes two input wic files and produces a tarball of their difference that can
+# be used in the field upgrade process
+# Params:
+#     1 - oldwic: .wic file of the base or factory build to be upgraded
+#     2 - newwic: .wic file of the new or upgrade build
+#     3 - tag:    optional text tag to be prepended to the output tarball
+# Output:
+#     <tag>-field-upgradeupdate.tar.gz
+main() {
+    local oldwic="$1"
+    local newwic="$2"
+    local tag
+    local success=1
+
+    [[ -z "$3" ]] && tag="data.tar.gz" || tag="${3}"-data.tar.gz
+
+    [ -f "${oldwic}" ] && [ -f "${newwic}" ] || {
+        echo >&2 "Usage: sudo createUpgrade.sh [--verbose] <old_wic_file> <new_wic_file> [upgrade_tag]"
+        echo >&2 "    old_wic_file        - base image for upgrade"
+        echo >&2 "    new_wic_file        - result image for upgrade"
+        echo >&2 "    upgrade_tag         - optional text string prepended to output tarball filename"
+        return 1
+    }
+
+    # Make sure we have all the binaries we need; gzcat can be substituted
+    type gzcat >/dev/null 2>&1 || gzcat() { gzip -c -d -f "$@"; }
+    require_binaries gzip gzcat xz tar openssl md5sum grep rsync mount umount fdisk sfdisk || return 2
+
+    # TODO: Right now, commands run as sudo (e.g. rsync) create files with root as owner, thus requiring pretty much the entire remaining script to be run as root as well. Fix it.
+    # Ensure we are running as root
+    [ $(id -u) -ne 0 ] && {
+        echo >&2 "Please run as root"
+        return 3
+    }
+
+    # Create tmp working space
+    setupTemp
+
+    md5sum $oldwic | awk -v srch="$oldwic" -v repl="$newwic" '{ sub(srch,repl,$0); print $0 }' > ${TMPDIR}/chksum.txt
+    md5sum -c ${TMPDIR}/chksum.txt 2>/dev/null | grep -q "OK" && {
+        echo >&2 "Base image and result image are the same! Please make sure they are different."
+        return 4
+    }
+
+    # If input wic files are gzipped, gunzip them otherwise copy them as is
+    gzcat -f "$oldwic" > ${TMPDIR}/old_wic
+    gzcat -f "$newwic" > ${TMPDIR}/new_wic
+
+    ostree_diff_partition ${TMPDIR}/old_wic ${TMPDIR}/new_wic 2 || {
+            success=0
+            break
+        }
+
+    mv ${TMPDIR}/delta/data.tar.gz ${tag}
+
+    # Cleanup the temp working space
+    cleanup
+}
+
+[ "$1" = "--verbose" ] && VERBOSE=1 && TARVFLAG=v && shift
+main "$@"

--- a/ostree/ostree-delta-docker.sh
+++ b/ostree/ostree-delta-docker.sh
@@ -1,8 +1,19 @@
 #!/bin/bash
 
-# Copyright (c) 2018-2019, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2021, Pelion Limited and affiliates.
+# SPDX-License-Identifier: Apache-2.0
 #
-# SPDX-License-Identifier: BSD-3-Clause
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 set -e
 set -u

--- a/ostree/ostree-delta-docker.sh
+++ b/ostree/ostree-delta-docker.sh
@@ -1,0 +1,198 @@
+#!/bin/bash
+
+# Copyright (c) 2018-2019, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+set -e
+set -u
+
+execdir="$(readlink -e "$(dirname "$0")")"
+srcdir="$execdir"/Docker
+
+# Load the config functions
+# shellcheck disable=SC1090
+source "$srcdir/config-funcs.sh"
+
+imagename="ostree-delta-update-tools"
+containername="ostree-delta-update-container.$$"
+build_script=ostree-delta.py
+dockerfile=Docker/Dockerfile
+
+trap cleanup 0
+
+cleanup() {
+    # This command will return an id (eg. 43008e2a9f5a) of the running
+    # container
+    running_container="$(docker ps -q -f name="$containername")"
+    if [ ! -z "$running_container" ]; then
+        docker kill "$containername"
+    fi
+}
+
+quiet_printf() {
+    if [ "$quiet" -ne 1 ]; then
+        # Shellcheck warns about printf's format string being variable, but
+        # quiet_printf is just forwarding args to printf, so it's
+        # quiet_printf's caller's responsibility to ensure that quiet_printf's
+        # format string isn't variable.
+        # shellcheck disable=SC2059
+        printf "$@"
+    fi
+}
+
+run_quietly() {
+    if [ "$quiet" -ne 1 ]; then
+        "$@"
+    else
+        "$@" > /dev/null
+    fi
+}
+
+
+usage()
+{
+  cat <<EOF
+
+usage: ostree-delta-docker.sh [OPTION] -- [build.sh arguments]
+
+MANDATORY parameters:
+  --output PATH      Specify the output folder
+  --repo PATH        Specify the root of the build tree.
+
+OPTIONAL parameters:
+  --update_repo PATH        Specify the root of the build tree.
+  -h, --help            Print brief usage information and exit.
+  --quiet               Reduce amount of output.
+  -x                    Enable shell debugging in this script.
+
+EOF
+}
+
+flag_tty="-t"
+quiet=0
+
+# Read or write configuration files and return combined args array
+config=()
+config_setup config "$@"
+
+# Set up args including values from config
+# Shell check wants us to quote the printf substitution to prevent word
+# splitting here, but we *want* word splitting of printf's output. The "%q" in
+# printf's format string means that the word splitting will happen in the right
+# places.
+# shellcheck disable=SC2046
+eval set -- "${config[@]}"
+
+# Save the full command line for later - when we do a binary release we want a
+# record of how this script was invoked
+command_line="$(printf '%q ' "$0" "$@")"
+
+args_list="output:"
+args_list="${args_list},repo:"
+args_list="${args_list},update_repo:"
+args_list="${args_list},help"
+args_list="${args_list},quiet"
+
+args=$(getopt -o+ho:x -l $args_list -n "$(basename "$0")" -- "$@")
+eval set -- "$args"
+
+while [ $# -gt 0 ]; do
+  if [ -n "${opt_prev:-}" ]; then
+    eval "$opt_prev=\$1"
+    opt_prev=
+    shift 1
+    continue
+  elif [ -n "${opt_append:-}" ]; then
+    eval "$opt_append=\"\${$opt_append:-} \$1\""
+    opt_append=
+    shift 1
+    continue
+  fi
+  case $1 in
+  --repo)
+    opt_prev=repo
+    ;;
+
+  -h | --help)
+    usage
+    exit 0
+    ;;
+
+  --update_repo)
+    opt_prev=update_repo
+    ;;
+
+  -o | --output)
+    opt_prev=output
+    ;;
+
+  --quiet)
+    quiet=1
+    ;;
+
+  -x)
+    set -x
+    ;;
+
+  --)
+    shift
+    break 2
+    ;;
+  esac
+  shift 1
+done
+
+if [ -n "${repo:-}" ]; then
+  repo=$(readlink -f "$repo")
+  if [ ! -d "$repo" ]; then
+    quiet_printf "missing repo %s.\n" "$repo"
+    exit 1
+  fi
+else
+  quiet_printf "missing repo argument.\n" 
+  exit 1
+fi
+
+if [ -n "${output:-}" ]; then
+  output=$(readlink -f "$output")
+  if [ ! -d "$output" ]; then
+    quiet_printf "missing output %s. Creating it.\n" "$output"
+    mkdir -p "$output"
+  fi
+else
+  quiet_printf "missing output argument.\n" 
+  exit 1
+fi
+
+if [ -n "${update_repo:-}" ]; then
+  update_repo=$(readlink -f "$update_repo")
+  if [ ! -d "$update_repo" ]; then
+    quiet_printf "missing repo %s.\n"
+    exit 1
+  fi
+fi
+
+dockerfile_path="$execdir/$dockerfile"
+
+# Build the docker build environment
+set -x
+run_quietly docker build -f "$dockerfile_path" -t "$imagename" "$execdir"
+
+set -x
+
+# The ${:+} expansion of download upsets shellcheck, but we do not
+# want that instance quoted because that would inject an empty
+# argument when download is not defined.
+# shellcheck disable=SC2086
+docker run --rm -i $flag_tty \
+       --name "$containername" \
+       -e LOCAL_UID="$(id -u)" -e LOCAL_GID="$(id -g)" \
+       ${repo:+-v "$repo":"$repo"} \
+       ${output:+-v "$output":"$output"} \
+       ${update_repo:+-v "$update_repo":"$update_repo"} \
+       "$imagename" \
+       ./${build_script} --repo "$repo" \
+         --output "$output" \
+         ${update_repo:+--update_repo "$update_repo"} \
+         "$@"

--- a/ostree/ostree-delta.py
+++ b/ostree/ostree-delta.py
@@ -1,0 +1,446 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2019, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""
+Script to create a static delta bteween 2 ostree repos.
+
+"""
+
+import argparse
+import os
+import pathlib
+import shutil
+import subprocess
+import sys
+import warnings
+import tarfile
+
+
+def warning_on_one_line(message, category, filename, lineno, file=None, line=None):
+    """Format a warning the standard way."""
+    return "{}:{}: {}: {}\n".format(filename, lineno, category.__name__, message)
+
+
+def warning(message):
+    """
+    Issue a UserWarning Warning.
+
+    Args:
+    * message: warning's message
+
+    """
+    warnings.warn(message, stacklevel=2)
+    sys.stderr.flush()
+
+
+def _execute_command(command, timeout=None):
+
+    print(command)
+    p = subprocess.Popen(
+        command,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        bufsize=-1,
+        universal_newlines=True,
+    )
+    try:
+        output, error = p.communicate(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        ExecuteHelper._print("Timed out after {}s".format(timeout))
+        p.kill()
+        output, error = p.communicate()
+
+    print(error)
+
+    return output
+
+
+def _determine_machine_from_repo(repo):
+
+    # Get the refs from the repo, and discard the ones that start "ostree".
+    # This is so we can auto-detect the machine tyoe from the repo, which
+    # is important for when the repo comes from a compile wic file.
+
+    command = ["ostree", "--repo={}".format(repo), "refs"]
+    output = _execute_command(command).rstrip().splitlines()
+
+    machine = None
+
+    # Search through the refs and take the first one that doesn't start
+    # with "ostree". This will be the base repo.
+    for ref in output:
+        if not ref.startswith("ostree"):
+            machine = ref
+            break
+    return machine
+
+
+def _get_data_from_repo(repo, machine, data):
+    # Get the data from the repo
+
+    values = []
+
+    command = ["ostree", "--repo={}".format(repo), "log", machine]
+    output = _execute_command(command).rstrip().splitlines()
+    for line in output:
+
+        if line.startswith(data):
+            values.append(line.split()[1])
+    if len(values) > 0:
+        return values
+    else:
+        return None
+
+
+def _get_shas_from_repo(repo, machine):
+    # Get the sha from the repo
+    return _get_data_from_repo(repo, machine, "commit")
+
+
+def _get_version_from_repo(repo, machine):
+    # Get the sha from the repo
+    return _get_data_from_repo(repo, machine, "Version")
+
+
+def _generate_metadata(outputpath, from_sha, to_sha):
+    # Save the from and to shas into a file. They will be needed on the device at the deploy stage.
+    with open(os.path.join(outputpath, "metadata"), "w") as metafile:
+        metafile.write("From-sha:{}\n".format(from_sha))
+        metafile.write("To-sha:{}\n".format(to_sha))
+
+
+def _generate_tarball(outputpath):
+
+    command = [
+        "tar",
+        "-cf",
+        "{}/data.tar".format(outputpath),
+        "--directory",
+        outputpath,
+        "--exclude=./data.tar",
+        ".",
+    ]
+    output = _execute_command(command)
+    print(output)
+
+    command = ["gzip", "--force", "{}/data.tar".format(outputpath)]
+    output = _execute_command(command)
+    print(output)
+
+
+def _generate_static_delta_between_repos(
+    repo, update_repo, outputpath, commit, machine, update_sha, from_sha
+):
+    """
+    Generate the static delta information.
+
+    Args:
+    * repo        (Path): Initial (deployed) repository.
+    * update_repo (Path): New (update) repository. 
+    * outputpath  (Path): output folder.
+    * commit,
+    * machine,
+    * update_sha,
+    * from_sha,
+
+    """
+
+    # Get the sha from the new repo
+    shas = _get_shas_from_repo(update_repo, machine)
+
+    if update_sha is None:
+        update_sha = shas[0]
+    else:
+        if update_sha not in shas:
+            warning(
+                "sha {} not found in {} for ref {}".format(
+                    update_sha, update_repo, machine
+                )
+            )
+            exit(1)
+
+    print(update_sha)
+
+    versions = _get_version_from_repo(update_repo, machine)
+
+    # Get the sha from the deployed repo
+    shas = _get_shas_from_repo(repo, machine)
+
+    if from_sha is None:
+        from_sha = shas[0]
+    else:
+        if from_sha not in shas:
+            warning("sha {} not found in {} for ref {}".format(from_sha, repo, machine))
+            exit(1)
+
+    print(from_sha)
+
+    # Pull the new repo into the old repo.
+    command = [
+        "ostree",
+        "--repo={}".format(repo),
+        "pull-local",
+        "{}".format(update_repo),
+        update_sha,
+    ]
+    output = _execute_command(command)
+    print(output)
+
+    # And commit it.
+    command = [
+        "ostree",
+        "--repo={}".format(repo),
+        "commit",
+        "-b",
+        machine,
+        "-s",
+        '"{}"'.format(commit),
+        "--add-metadata-string=version={}".format(versions[0]),
+        "--tree=ref={}".format(update_sha),
+    ]
+    commit_sha = _execute_command(command).rstrip()
+    print(commit_sha)
+
+    _generate_metadata(outputpath, from_sha, commit_sha)
+
+    command = ["ostree", "--repo={}".format(repo), "summary", "-u"]
+    output = _execute_command(command)
+    print(output)
+
+    output_filename = os.path.join(outputpath, "superblock")
+
+    # Generate the static delta.
+    # the max-chunk-size gives the delta in a single data file, called 0
+    command = [
+        "ostree",
+        "--repo={}".format(repo),
+        "static-delta",
+        "generate",
+        machine,
+        "--max-chunk-size=2048",
+        "--filename={}".format(output_filename),
+        "--from",
+        from_sha,
+        "--to",
+        commit_sha,
+    ]
+    output = _execute_command(command)
+    print(output)
+
+    command = ["ostree", "--repo={}".format(repo), "summary", "-u"]
+    output = _execute_command(command)
+    print(output)
+
+    # Create a tarball.
+    _generate_tarball(outputpath)
+
+
+def _generate_static_delta_between_shas(repo, outputpath, machine, to_sha, from_sha):
+    """
+    Generate the static delta information.
+
+    Args:
+    * repo        (Path): Initial (deployed) repository.
+    * outputpath  (Path): output folder.
+    * machine,
+    * to_sha,
+    * from_sha,
+
+    """
+
+    shas = _get_shas_from_repo(repo, machine)
+
+    if len(shas) < 2:
+        warning("Not enough commits found is {}".format(repo))
+        exit(1)
+
+    if to_sha is None:
+        to_sha = shas[0]
+    else:
+        if to_sha not in shas:
+            warning("sha {} not found in {} for ref {}".format(to_sha, repo, machine))
+            exit(1)
+
+    if from_sha is None:
+        from_sha = shas[1]
+    else:
+        if from_sha not in shas:
+            warning("sha {} not found in {} for ref {}".format(from_sha, repo, machine))
+            exit(1)
+
+    _generate_metadata(outputpath, from_sha, to_sha)
+
+    output_filename = os.path.join(outputpath, "superblock")
+
+    # Generate the static delta.
+    # the max-chunk-size gives the delta in a single data file, called 0
+    command = [
+        "ostree",
+        "--repo={}".format(repo),
+        "static-delta",
+        "generate",
+        machine,
+        "--max-chunk-size=2048",
+        "--filename={}".format(output_filename),
+        "--from",
+        from_sha,
+        "--to",
+        to_sha,
+    ]
+    output = _execute_command(command)
+    print(output)
+
+    # Create a tarball.
+    _generate_tarball(outputpath)
+
+
+def _str_to_resolved_path(path_str):
+    """
+    Convert a string to a resolved Path object.
+
+    Args:
+    * path_str (str): string to convert to a Path object.
+
+    """
+    return pathlib.Path(path_str).resolve(strict=False)
+
+
+def ensure_is_directory(path):
+    """
+    Check that a file exists and is a directory.
+
+    Raises an exception on failure and does nothing on success
+
+    Args:
+    * path (PathLike): path to check.
+
+    """
+    path = pathlib.Path(path)
+    if not path.exists():
+        raise ValueError('"{}" does not exist'.format(path))
+    if not path.is_dir():
+        raise ValueError('"{}" is not a directory'.format(path))
+
+
+def _parse_args():
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "--repo",
+        metavar="DIR",
+        type=_str_to_resolved_path,
+        help="Initial (deployed) repo.",
+        required=True,
+    )
+
+    parser.add_argument(
+        "--output",
+        metavar="DIR",
+        type=_str_to_resolved_path,
+        help="Output Folder. Will be created if necessary.",
+        required=True,
+    )
+
+    parser.add_argument(
+        "--update_repo",
+        metavar="DIR",
+        type=_str_to_resolved_path,
+        help="New (update) repo.",
+        required=False,
+    )
+
+    parser.add_argument(
+        "--machine",
+        type=str,
+        help="Machine (and therfore ref) being worked on",
+        required=False,
+    )
+
+    parser.add_argument(
+        "--to_sha", type=str, help="sha of the tip of the delta image", required=False
+    )
+
+    parser.add_argument(
+        "--from_sha",
+        type=str,
+        help="sha of the base of the delta image",
+        required=False,
+    )
+
+    parser.add_argument(
+        "--commit",
+        type=str,
+        help="Commit message when merging 2 repos",
+        default="OSTree Delta Generation",
+        required=False,
+    )
+
+    parser.add_argument(
+        "--generate_bin",
+        action="store_true",
+        help="Create a .bin file instead of .tar.gz",
+        default=False,
+        required=False,
+    )
+
+    args, unknown = parser.parse_known_args()
+
+    if len(unknown) > 0:
+        warning("unsupported arguments: {}".format(unknown))
+
+    ensure_is_directory(args.repo)
+
+    return args
+
+
+def main():
+    """Script entry point."""
+    warnings.formatwarning = warning_on_one_line
+
+    args = _parse_args()
+
+    os.makedirs(args.output, exist_ok=True)
+
+    if args.machine is None:
+        machine = _determine_machine_from_repo(repo=args.repo)
+    else:
+        machine = args.machine
+
+    if args.update_repo is None:
+        print(_generate_static_delta_between_shas)
+        _generate_static_delta_between_shas(
+            repo=args.repo,
+            outputpath=args.output,
+            machine=machine,
+            to_sha=args.to_sha,
+            from_sha=args.from_sha,
+        )
+    else:
+        print(_generate_static_delta_between_repos)
+        _generate_static_delta_between_repos(
+            repo=args.repo,
+            update_repo=args.update_repo,
+            outputpath=args.output,
+            commit=args.commit,
+            machine=machine,
+            update_sha=args.to_sha,
+            from_sha=args.from_sha,
+        )
+
+    if args.generate_bin:
+        # Rename the tar-gz file to .bin to avoid a "feature" with manifest generation.
+        command = [
+            "mv",
+            "{}/data.tar.gz".format(args.output),
+            "{}/data.bin".format(args.output),
+        ]
+        output = _execute_command(command)
+        print(output)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ostree/ostree-delta.py
+++ b/ostree/ostree-delta.py
@@ -1,8 +1,19 @@
 #!/usr/bin/env python3
 
-# Copyright (c) 2019, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2021, Pelion Limited and affiliates.
+# SPDX-License-Identifier: Apache-2.0
 #
-# SPDX-License-Identifier: BSD-3-Clause
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 """
 Script to create a static delta bteween 2 ostree repos.


### PR DESCRIPTION
Added scripts for the generation of ostree static delta images.

ostree-delta.py does all of the heavy lifting.

If 2 repos are provided it pulls one into the other and creates the
static delta between them.
If a single repo is provided then it produces the static delta between
the last 2 commits.
Optionally specific shas can be provided to create the diffs between
specific commits.

The createOSTreeUpgrade.sh script mounts the ostree repos from the old
and new wic files and then calls upon ostree-delta.py to produce the
static delta between these two repos.